### PR TITLE
Typo fixing in RelationStrings.xml

### DIFF
--- a/dotnet/xml/Microsoft.EntityFrameworkCore.Diagnostics/RelationalStrings.xml
+++ b/dotnet/xml/Microsoft.EntityFrameworkCore.Diagnostics/RelationalStrings.xml
@@ -3769,7 +3769,7 @@
       </ReturnValue>
       <Docs>
         <summary>
-                Unable to translate set operation when both sides don't assign values to same properties in the nominal type. Please make sure that the properties are inclued on both sides, consider assigning default value if the property doesn't require a specific value.
+                Unable to translate set operation when both sides don't assign values to same properties in the nominal type. Please make sure that the properties are included on both sides, consider assigning default value if the property doesn't require a specific value.
             </summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>


### PR DESCRIPTION
Fixed a typo in a summary message of ProjectionMappingCountMismatch: inclued -> included