### PR TITLE
WithMany navigationExpression: blog => blog.Posts

### DIFF
--- a/dotnet/xml/Microsoft.EntityFrameworkCore.Metadata.Builders/CollectionNavigationBuilder`2.xml
+++ b/dotnet/xml/Microsoft.EntityFrameworkCore.Metadata.Builders/CollectionNavigationBuilder`2.xml
@@ -276,7 +276,7 @@
       <Docs>
         <param name="navigationExpression">
                 A lambda expression representing the reference navigation property on the other end of this
-                relationship (<c>post =&gt; post.Blog</c>). If no property is specified, the relationship will be
+                relationship (<c>blog =&gt; blog.Posts</c>). If no property is specified, the relationship will be
                 configured without a navigation property on the other end of the relationship.
             </param>
         <summary>


### PR DESCRIPTION
Fixes dotnet/EntityFramework.Docs#3612 (hopefully)