### PR TITLE
Fix breadcrumbs

### DIFF
--- a/EF/docfx.json
+++ b/EF/docfx.json
@@ -48,7 +48,6 @@
       "author": "dotnet-bot",
       "ms.author": "avickers",
       "breadcrumb_path": "~/breadcrumb/toc.yml",
-      "extendBreadcrumb": true,
       "searchScope": ["Entity Framework"],
       "ms.topic": "managed-reference",
       "ms.prod": "entity-framework",

--- a/EF/docfx.json
+++ b/EF/docfx.json
@@ -47,7 +47,7 @@
       "apiPlatform": "dotnet",
       "author": "dotnet-bot",
       "ms.author": "avickers",
-      "breadcrumb_path": "~/breadcrumb/toc.yml",
+      "breadcrumb_path": "~/breadcrumb/toc.json",
       "searchScope": ["Entity Framework"],
       "ms.topic": "managed-reference",
       "ms.prod": "entity-framework",

--- a/EF/docfx.json
+++ b/EF/docfx.json
@@ -47,7 +47,7 @@
       "apiPlatform": "dotnet",
       "author": "dotnet-bot",
       "ms.author": "avickers",
-      "breadcrumb_path": "~/breadcrumb/toc.json",
+      "breadcrumb_path": "/dotnet/breadcrumb/toc.json",
       "searchScope": ["Entity Framework"],
       "ms.topic": "managed-reference",
       "ms.prod": "entity-framework",

--- a/dotnet/breadcrumb/toc.yml
+++ b/dotnet/breadcrumb/toc.yml
@@ -1,7 +1,7 @@
-- name: Docs
-  tocHref: /
-  topicHref: /
+- name: .NET
+  tocHref:/dotnet/
+  topicHref: /dotnet/index
   items:
-  - name: .NET API Browser
+  - name: API browser
     tocHref: /dotnet/api/
     topicHref: /dotnet/api/index

--- a/dotnet/breadcrumb/toc.yml
+++ b/dotnet/breadcrumb/toc.yml
@@ -1,5 +1,5 @@
 - name: .NET
-  tocHref:/dotnet/
+  tocHref: /dotnet/
   topicHref: /dotnet/index
   items:
   - name: API browser

--- a/dotnet/docfx.json
+++ b/dotnet/docfx.json
@@ -50,7 +50,6 @@
       "author": "dotnet-bot",
       "ms.author": "avickers",
       "breadcrumb_path": "~/breadcrumb/toc.yml",
-      "extendBreadcrumb": true,
       "searchScope": ["Entity Framework"],
       "ms.topic": "managed-reference",
       "ms.prod": "ef-core-api",

--- a/dotnet/docfx.json
+++ b/dotnet/docfx.json
@@ -49,7 +49,7 @@
       "apiPlatform": "dotnet",
       "author": "dotnet-bot",
       "ms.author": "avickers",
-      "breadcrumb_path": "~/breadcrumb/toc.json",
+      "breadcrumb_path": "/dotnet/breadcrumb/toc.json",
       "searchScope": ["Entity Framework"],
       "ms.topic": "managed-reference",
       "ms.prod": "ef-core-api",

--- a/dotnet/docfx.json
+++ b/dotnet/docfx.json
@@ -49,7 +49,7 @@
       "apiPlatform": "dotnet",
       "author": "dotnet-bot",
       "ms.author": "avickers",
-      "breadcrumb_path": "~/breadcrumb/toc.yml",
+      "breadcrumb_path": "~/breadcrumb/toc.json",
       "searchScope": ["Entity Framework"],
       "ms.topic": "managed-reference",
       "ms.prod": "ef-core-api",


### PR DESCRIPTION
This PR brings breadcrumb implementation into alignment with [platform architecture requirements](https://review.learn.microsoft.com/en-us/help/platform/navigation-overview?branch=main#requirements-for-content-ecosystems). This PR is part of a previously announced batch of breadcrumb fixes across the Learn platform and will be auto-merged if there are no build warnings. This PR may include removing the “extend breadcrumb” feature from any docfx files that are still using it, fixing breadcrumb file references in the docfx file, and rewriting breadcrumb files to match the [approved breadcrumb pattern](https://review.learn.microsoft.com/en-us/help/platform/navigation-breadcrumbs-overview?branch=main#breadcrumbs-in-documentation) for a given product’s documentation. 
