### PR TITLE
Configure open source feedback

### DIFF
--- a/dotnet/docfx.json
+++ b/dotnet/docfx.json
@@ -60,9 +60,15 @@
         "https://authoring-docs-microsoft.poolparty.biz/devrel/8eb81391-e81d-4461-aa4a-9512fd4bbed8",
         "https://authoring-docs-microsoft.poolparty.biz/devrel/56a03cf0-cabf-4e70-800b-dcb9ff39361c"
       ],
-      "feedback_system": "GitHub",
+      "feedback_system": "OpenSource",
       "feedback_github_repo": "dotnet/EntityFramework.Docs",
-      "feedback_product_url": "https://github.com/dotnet/efcore/issues/new"
+      "feedback_product_url": "https://github.com/dotnet/efcore/issues/new",
+      "open_source_feedback_contributorGuideUrl": "https://learn.microsoft.com/contribute/content/dotnet/dotnet-contribute",
+      "open_source_feedback_issueTitle": "",
+      "open_source_feedback_productLogoLightUrl": "https://learn.microsoft.com/media/logos/logo_net.svg",
+      "open_source_feedback_productLogoDarkUrl": "https://learn.microsoft.com/media/logos/logo_net.svg",
+      "open_source_feedback_issueUrl": "https://github.com/dotnet/EntityFramework.Docs/issues/new?template=z-customer-feedback.yml",
+      "open_source_feedback_productName": "Entity Framework"
     },
     "fileMetadata":{
       "langs": {


### PR DESCRIPTION
Configure the open source feedback control for Entity Framework API docs.

Relies on dotnet/EntityFramework.Docs#4640