### PR TITLE
Configure feedback for OSS

### DIFF
--- a/EF/docfx.json
+++ b/EF/docfx.json
@@ -57,9 +57,15 @@
         "https://authoring-docs-microsoft.poolparty.biz/devrel/7696cda6-0510-47f6-8302-71bb5d2e28cf",
         "https://authoring-docs-microsoft.poolparty.biz/devrel/8eb81391-e81d-4461-aa4a-9512fd4bbed8"
       ],
-      "feedback_system": "GitHub",
+      "feedback_system": "OpenSource",
       "feedback_github_repo": "dotnet/EntityFramework.Docs",
-      "feedback_product_url": "https://github.com/dotnet/ef6/issues/new"
+      "feedback_product_url": "https://github.com/dotnet/ef6/issues/new",
+      "open_source_feedback_contributorGuideUrl": "https://learn.microsoft.com/contribute/content/dotnet/dotnet-contribute",
+      "open_source_feedback_issueTitle": "",
+      "open_source_feedback_productLogoLightUrl": "https://learn.microsoft.com/media/logos/logo_net.svg",
+      "open_source_feedback_productLogoDarkUrl": "https://learn.microsoft.com/media/logos/logo_net.svg",
+      "open_source_feedback_issueUrl": "https://github.com/dotnet/EntityFramework.Docs/issues/new?template=z-customer-feedback.yml",
+      "open_source_feedback_productName": "Entity Framework"
     },
     "fileMetadata": {},
     "template": [],


### PR DESCRIPTION
In #141, I missed the second docfx.json for the Entity Framework 6 docs. This PR adds those updates.